### PR TITLE
Refactor GetMostRecentEntry to use generics

### DIFF
--- a/GetWeather2.cs
+++ b/GetWeather2.cs
@@ -32,15 +32,14 @@ namespace uk.me.timallen.infohub
             log.LogInformation("lat: " + lat + " lng:" + lng);
 
             // var table = GetStorageTable("weather");
-            // var result = GetMostRecentEntry( table, lat + "," + lng);
+            // var result = GetMostRecentEntry<Weather>(table, lat + "," + lng).Forecast;
             var result = OpenWeather.GetForecast(lat, lng);
             return new OkObjectResult(result);
         }
 
-// TODO: Use a generic here to reuse the code
-        public static string GetMostRecentEntry(CloudTable table, string partitionKey)
+        public static T GetMostRecentEntry<T>(CloudTable table, string partitionKey) where T : ITableEntity, new()
         {
-            var query = new TableQuery<Weather>()
+            var query = new TableQuery<T>()
                 .Where(
                     TableQuery.GenerateFilterCondition(
                         "PartitionKey", 
@@ -51,11 +50,7 @@ namespace uk.me.timallen.infohub
                 new TableContinuationToken()
                 ).Result.Results;
 
-            var orderedForecasts = from s in items
-                                    orderby s.Timestamp 
-                                    select s;
-
-            return orderedForecasts.First().Forecast;
+            return items.OrderByDescending(s => s.Timestamp).FirstOrDefault();
         }
 
         public static CloudTable GetStorageTable(string table)


### PR DESCRIPTION
This change refactors the `GetMostRecentEntry` method in `GetWeather2.cs` to use generics, as requested. The method now handles any `ITableEntity` type, promoting code reuse. Additionally, the sorting logic was updated to correctly return the most recent entry by ordering by `Timestamp` in descending order. The commented-out code in the `Run` method was also updated to reflect these changes.

---
*PR created automatically by Jules for task [1748210651315378643](https://jules.google.com/task/1748210651315378643) started by @tafallen*