### PR TITLE
⚡ Make OpenWeather.GetForecast Async

### DIFF
--- a/CacheWeather.cs
+++ b/CacheWeather.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 
@@ -15,14 +16,14 @@ namespace uk.me.timallen.infohub
 
         [FunctionName("CacheWeather")]
         [return: Table("weather")]
-        public static WeatherForecast Run([TimerTrigger("* 0 */6 * * *")]TimerInfo myTimer, ILogger log)
+        public static async Task<WeatherForecast> Run([TimerTrigger("* 0 */6 * * *")]TimerInfo myTimer, ILogger log)
         {
             var lat = Environment.GetEnvironmentVariable("weatherlat");
             var lng = Environment.GetEnvironmentVariable("weatherlng");
 
             log.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-            var forecast = OpenWeather.GetForecast(lat, lng);
+            var forecast = await OpenWeather.GetForecastAsync(lat, lng);
 
             log.LogInformation(forecast);
 

--- a/GetWeather2.cs
+++ b/GetWeather2.cs
@@ -33,7 +33,7 @@ namespace uk.me.timallen.infohub
 
             // var table = GetStorageTable("weather");
             // var result = GetMostRecentEntry<Weather>(table, lat + "," + lng).Forecast;
-            var result = OpenWeather.GetForecast(lat, lng);
+            var result = await OpenWeather.GetForecastAsync(lat, lng);
             return new OkObjectResult(result);
         }
 

--- a/logic/OpenWeather.cs
+++ b/logic/OpenWeather.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RestSharp;
 
@@ -6,19 +8,19 @@ namespace uk.me.timallen.infohub
 {
     public static class OpenWeather
     {
-        public static string GetForecast(string lat, string lng)
+        public static async Task<string> GetForecastAsync(string lat, string lng)
         {
-            var response = MakeRequest(lat,lng);
+            var response = await MakeRequestAsync(lat,lng);
             dynamic weather = JsonConvert.DeserializeObject(response.Content);
             var dailyForecasts = weather["daily"];
             return FormatResponse(dailyForecasts);
         }
 
-        private static IRestResponse MakeRequest(string lat, string lng)
+        private static async Task<IRestResponse> MakeRequestAsync(string lat, string lng)
         {
             var client = GetRestClient(lat, lng);
             var request = new RestRequest(Method.GET);
-            return client.Execute(request);
+            return await client.ExecuteAsync(request, CancellationToken.None);
         }        
 
         private static RestClient GetRestClient(string lat, string lng)


### PR DESCRIPTION
Refactored OpenWeather.GetForecast to GetForecastAsync using RestSharp's ExecuteAsync. Updated GetWeather2 and CacheWeather to await the new method. This eliminates blocking synchronous I/O in the Azure Function.

---
*PR created automatically by Jules for task [17809685925629499892](https://jules.google.com/task/17809685925629499892) started by @tafallen*