### PR TITLE
⚡ Optimize GetNews with async/await

### DIFF
--- a/CacheNews.cs
+++ b/CacheNews.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 
@@ -8,14 +9,14 @@ namespace uk.me.timallen.infohub
     {
         [FunctionName("CacheNews")]
         [return: Table("news")]
-        public static NewsArticles Run([TimerTrigger("* 0 */6 * * *")]TimerInfo myTimer, ILogger log)
+        public static async Task<NewsArticles> Run([TimerTrigger("* 0 */6 * * *")]TimerInfo myTimer, ILogger log)
         //public static NewsArticles Run([TimerTrigger("* * * * * *")]TimerInfo myTimer, ILogger log)
         {
             var result = new NewsArticles
             {
                 PartitionKey = "bbc-news",
                 RowKey = Guid.NewGuid().ToString(),
-                Articles = News.GetNews()
+                Articles = await News.GetNewsAsync()
             };
             return result;
         }

--- a/GetNews.cs
+++ b/GetNews.cs
@@ -14,7 +14,7 @@ namespace uk.me.timallen.infohub
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequest req,
             ILogger log)
         {
-            var response = News.GetNews();
+            var response = await News.GetNewsAsync();
 
             log.LogInformation(response);
 

--- a/logic/News.cs
+++ b/logic/News.cs
@@ -3,15 +3,16 @@ using NewsAPI;
 using NewsAPI.Models;
 using NewsAPI.Constants;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace uk.me.timallen.infohub
 {
     public static class News
     {
 
-        public static string GetNews()
+        public static async Task<string> GetNewsAsync()
         {
-            var articles = GetArticles();
+            var articles = await GetArticlesAsync();
             string result = FormatResponse(articles);
             return result;
         }
@@ -40,13 +41,13 @@ namespace uk.me.timallen.infohub
             return result;
         }
 
-        private static IList<Article> GetArticles()
+        private static async Task<IList<Article>> GetArticlesAsync()
         {
             var newsKey = Environment.GetEnvironmentVariable("news_key");
             var newsApiClient = new NewsApiClient(newsKey);
             var sources = new List<string>(new []{"bbc-news"});
 
-            var articlesResponse = newsApiClient.GetTopHeadlines( new TopHeadlinesRequest
+            var articlesResponse = await newsApiClient.GetTopHeadlinesAsync(new TopHeadlinesRequest
             {
                 Sources = sources,
                 Language = Languages.EN,


### PR DESCRIPTION
💡 **What:**
- Converted `News.GetNews` and `News.GetArticles` to asynchronous methods (`GetNewsAsync`, `GetArticlesAsync`).
- Updated `GetNews.cs` Azure Function to await `News.GetNewsAsync()`.
- Updated `CacheNews.cs` Azure Function to be async and await `News.GetNewsAsync()`.
- Utilized `NewsApiClient.GetTopHeadlinesAsync` for non-blocking I/O.

🎯 **Why:**
- The previous implementation used blocking synchronous I/O (`News.GetNews()`), which can lead to thread starvation in Azure Functions under load.
- Switching to `async/await` allows the function to release the thread while waiting for the external API response, improving scalability and throughput.

📊 **Measured Improvement:**
- **Baseline:** Synchronous execution blocks the thread for the duration of the HTTP request to NewsAPI.
- **Improvement:** Asynchronous execution frees the thread. While wall-clock time for a single request may be similar, the capacity to handle concurrent requests is significantly improved.
- **Note:** Local benchmarking was not possible due to environment constraints (.NET SDK mismatch) and lack of API keys, but the change follows standard best practices for I/O-bound operations in Azure Functions.

---
*PR created automatically by Jules for task [12989440648231025948](https://jules.google.com/task/12989440648231025948) started by @tafallen*