### PR TITLE
Comment out line to checkin web deploy settings in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,7 @@ publish/
 # TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 #*.pubxml
-*.publishproj
+#*.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
 # checkin your Azure Web App publish settings, but sensitive information contained


### PR DESCRIPTION
The task was to comment out a line in `.gitignore` to enable checking in web deploy settings. 
The line `*.publishproj` (line 150) was commented out (`#*.publishproj`).
I also verified that the change effectively stops Git from ignoring `.publishproj` files.
Tests were attempted but skipped due to persistent timeouts, which is acceptable given the non-code nature of the change.
A code review confirmed the change is correct.

---
*PR created automatically by Jules for task [3845903595424552232](https://jules.google.com/task/3845903595424552232) started by @tafallen*