### PR TITLE
⚡ Optimize dynamic property evaluation in AccuWeatherService loop

### DIFF
--- a/logic/AccuWeatherService.cs
+++ b/logic/AccuWeatherService.cs
@@ -51,8 +51,9 @@ namespace uk.me.timallen.infohub
         {
             var forecasts = new List<object>();
             var now = DateTime.Now;
+            int count = dailyForecasts.Count;
 
-            for(int i = 0; i < dailyForecasts.Count; i++)
+            for(int i = 0; i < count; i++)
             {
                 dynamic day = dailyForecasts[i];
                 forecasts.Add(new {


### PR DESCRIPTION
💡 **What:** The optimization implemented is caching the `.Count` property of a `dynamic` object into a local integer variable before it's used as a loop termination condition.
🎯 **Why:** In C#, accessing properties on a `dynamic` object involves expensive runtime binding via the Dynamic Language Runtime (DLR). Evaluating `.Count` on every iteration of a loop adds significant overhead, especially for larger collections.
📊 **Measured Improvement:** While environmental constraints and timeouts prevented a precise quantitative measurement in the sandbox, caching dynamic property evaluations is a well-established performance best practice in .NET to reduce CPU cycles spent on runtime member lookup.

---
*PR created automatically by Jules for task [1485179562274460821](https://jules.google.com/task/1485179562274460821) started by @tafallen*