### PR TITLE
Allow checkin of web deploy settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,17 +142,16 @@ DocProject/Help/html
 publish/
 
 # Publish Web Output
-*.[Pp]ublish.xml
-*.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings
+#*.[Pp]ublish.xml
+#*.azurePubxml
 # but database connection strings (with potential passwords) will be unencrypted
 #*.pubxml
 #*.publishproj
 
-# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# Microsoft Azure Web App publish settings.
 # checkin your Azure Web App publish settings, but sensitive information contained
 # in these scripts will be unencrypted
-PublishScripts/
+#PublishScripts/
 
 # NuGet Packages
 *.nupkg


### PR DESCRIPTION
This change modifies the .gitignore file to allow web deployment settings to be checked into the repository. It comments out the following patterns:
- *.[Pp]ublish.xml
- *.azurePubxml
- PublishScripts/

It also removes the TODO comment and the instructions to comment out these lines, as the task is now complete. This was done to support committing web deploy settings as requested.

---
*PR created automatically by Jules for task [10199716585347763420](https://jules.google.com/task/10199716585347763420) started by @tafallen*